### PR TITLE
added support for modules to have no dependencies

### DIFF
--- a/requirator.js
+++ b/requirator.js
@@ -27,6 +27,11 @@
     },
 
     moduleDefine = function(dependencies, fn, name) {
+      if (typeof dependencies === 'function') {
+        fn = dependencies;
+        dependencies = [];
+      }
+      
       foundModuleOrDefinition = true;
       if (areLoaded(dependencies)) {
         register(dependencies, fn, name);
@@ -170,10 +175,6 @@
    *      are loaded.
    */
   define = function(dependencies, fn) {
-    if (typeof dependencies === 'function') {
-      fn = dependencies;
-      dependencies = [];
-    }
     var name = loadStack[loadStack.length - 1];
     moduleDefine(dependencies, fn, name);
   };

--- a/requirator.js
+++ b/requirator.js
@@ -170,6 +170,10 @@
    *      are loaded.
    */
   define = function(dependencies, fn) {
+    if (typeof dependencies === 'function') {
+      fn = dependencies;
+      dependencies = [];
+    }
     var name = loadStack[loadStack.length - 1];
     moduleDefine(dependencies, fn, name);
   };


### PR DESCRIPTION
basic require allows simply a function to be loaded, i think ours should too.
